### PR TITLE
Add ap_upgrade_firmware.php to Examples

### DIFF
--- a/examples/ap_upgrade_firmware.php
+++ b/examples/ap_upgrade_firmware.php
@@ -19,7 +19,7 @@ $device_mac = 'de:ad:be:ef:01:23';
  * (this example assumes you have already assigned the correct values to the variables used)
  */
 
-$unifi_connection = new UniFi_API\Client($controller_user, $controller_password, $controller_url, $site_id, $controller_version, false);
+$unifi_connection = new UniFi_API\Client($controlleruser, $controllerpassword, $controllerurl, $site_id, $controllerversion, false);
 $login            = $unifi_connection->login();
 
 // Run the actual upgrade

--- a/examples/ap_upgrade_firmware.php
+++ b/examples/ap_upgrade_firmware.php
@@ -14,13 +14,6 @@ $site_id = 'default';
 // AP MAC address formatted with colons
 $device_mac = 'de:ad:be:ef:01:23';
 
-// If you have Debian/Ubuntu, grab the controller package version
-// Need to have exec function enabled for php-cli
-$controller_version  = exec("apt-cache show unifi | grep Version | sed 's/Version: //g;  s/-.*//g;'");
-
-// Or, you can just give this manually:
-// $controller_version = '5.7.20';
-
 /**
  * initialize the Unifi API connection class, log in to the controller and request the alarms collection
  * (this example assumes you have already assigned the correct values to the variables used)
@@ -38,4 +31,3 @@ $results = $unifi_connection->upgrade_device($device_mac);
 echo json_encode($results, JSON_PRETTY_PRINT);
 
 ?>
-

--- a/examples/ap_upgrade_firmware.php
+++ b/examples/ap_upgrade_firmware.php
@@ -1,0 +1,41 @@
+<?php
+
+/** 
+* Checks and upgrades AP firmware (can be scheduled with systemd/cron)
+**/
+
+require_once('vendor/autoload.php');
+require_once('config.php');
+
+// Because of a bug in the API, the site name is probably stuck at 'default' rather than what you actually named it:
+// https://github.com/Art-of-WiFi/UniFi-API-browser/issues/35
+$site_id = 'default';
+
+// AP MAC address formatted with colons
+$device_mac = 'de:ad:be:ef:01:23';
+
+// If you have Debian/Ubuntu, grab the controller package version
+// Need to have exec function enabled for php-cli
+$controller_version  = exec("apt-cache show unifi | grep Version | sed 's/Version: //g;  s/-.*//g;'");
+
+// Or, you can just give this manually:
+// $controller_version = '5.7.20';
+
+/**
+ * initialize the Unifi API connection class, log in to the controller and request the alarms collection
+ * (this example assumes you have already assigned the correct values to the variables used)
+ */
+
+$unifi_connection = new UniFi_API\Client($controller_user, $controller_password, $controller_url, $site_id, $controller_version, false);
+$login            = $unifi_connection->login();
+
+// Run the actual upgrade
+$results = $unifi_connection->upgrade_device($device_mac);
+
+/**
+ * provide feedback in json format from $response given by upgrade_device();
+ */
+echo json_encode($results, JSON_PRETTY_PRINT);
+
+?>
+

--- a/examples/config.template.php
+++ b/examples/config.template.php
@@ -13,10 +13,10 @@
  * Copy this file to your working directory, rename it to config.php and update the section below with your UniFi
  * controller details and credentials
  */
-$controller_user     = ''; // the user name for access to the UniFi Controller
-$controller_password = ''; // the password for access to the UniFi Controller
-$controller_url      = ''; // full url to the UniFi Controller, eg. 'https://22.22.11.11:8443'
-$controller_version  = ''; // the version of the Controller software, eg. '4.6.6' (must be at least 4.0.0)
+$controlleruser     = ''; // the user name for access to the UniFi Controller
+$controllerpassword = ''; // the password for access to the UniFi Controller
+$controllerurl      = ''; // full url to the UniFi Controller, eg. 'https://22.22.11.11:8443'
+$controllerversion  = ''; // the version of the Controller software, eg. '4.6.6' (must be at least 4.0.0)
 
 /**
  * set to true (without quotes) to enable debug output to the browser and the PHP error log

--- a/examples/config.template.php
+++ b/examples/config.template.php
@@ -13,10 +13,10 @@
  * Copy this file to your working directory, rename it to config.php and update the section below with your UniFi
  * controller details and credentials
  */
-$controlleruser     = ''; // the user name for access to the UniFi Controller
-$controllerpassword = ''; // the password for access to the UniFi Controller
-$controllerurl      = ''; // full url to the UniFi Controller, eg. 'https://22.22.11.11:8443'
-$controllerversion  = ''; // the version of the Controller software, eg. '4.6.6' (must be at least 4.0.0)
+$controller_user     = ''; // the user name for access to the UniFi Controller
+$controller_password = ''; // the password for access to the UniFi Controller
+$controller_url      = ''; // full url to the UniFi Controller, eg. 'https://22.22.11.11:8443'
+$controller_version  = ''; // the version of the Controller software, eg. '4.6.6' (must be at least 4.0.0)
 
 /**
  * set to true (without quotes) to enable debug output to the browser and the PHP error log


### PR DESCRIPTION
First, I wanted to say thank you for this! I realized recently that automatic firmware updates weren't happening for my Unifi AP for a while, and this lets me do a check for firmware updates automatically while also being able to control the scheduling. 

This is just a PoC for doing firmware upgrades via the API (my needs are simple since I only have one site/AP), but there are a few things that could be added to it to make it suitable for different environments:
- Grabbing the package version for non Ubuntu/Debian packages (macOS/Windows - you could run a similar package query with wmi)
- Automatically grabbing device MAC addresses (or manually specify multiple AP MACs in an array)
- More informative output from `$results` (similar to what one would get with email notifications). Right now, it only returns True if it was able to do an update check OK, but it would be nice if it could say whether it found an available update or not.

Cheers

**EDIT:** Just had another thought, for those that are more familiar with php, is `shell_exec` safer than `exec`? If so I can add that to the PR.