### PR TITLE
Add check_controller_update() and check_firmware_update() methods

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -2549,11 +2549,12 @@ class Client
 
     /**
      * Check controller update
-     * -----------------------
+     *
+     * NOTE:
+     * It's trigger an update of the controller cached known latest version.
+     *
      * @return array returns an array with a single object containing details of the current known latest controller version info
      *               on success, else returns false
-     *
-     * NOTE: It's trigger an update of the controller cached known latest version.
      */
     public function check_controller_update()
     {
@@ -2562,7 +2563,7 @@ class Client
 
     /**
      * Check firmware update
-     * ---------------------
+     *
      * @return bool returns true upon success
      */
     public function check_firmware_update()

--- a/src/Client.php
+++ b/src/Client.php
@@ -2550,7 +2550,8 @@ class Client
     /**
      * Check controller update
      * -----------------------
-     * returns current known latest controller version info
+     * @return array returns an array with a single object containing details of the current known latest controller version info
+     *               on success, else returns false
      *
      * NOTE: It's trigger an update of the controller cached known latest version.
      */
@@ -2562,7 +2563,7 @@ class Client
     /**
      * Check firmware update
      * ---------------------
-     * return true on success
+     * @return bool returns true upon success
      */
     public function check_firmware_update()
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -2548,6 +2548,30 @@ class Client
     }
 
     /**
+     * Check controller update
+     * -----------------------
+     * returns current known latest controller version info
+     *
+     * NOTE: It's trigger an update of the controller cached known latest version.
+     */
+    public function check_controller_update()
+    {
+        return $this->fetch_results('/api/s/' . $this->site . '/stat/fwupdate/latest-version');
+    }
+
+    /**
+     * Check firmware update
+     * ---------------------
+     * return true on success
+     */
+    public function check_firmware_update()
+    {
+        $payload = ['cmd' => 'check-firmware-update'];
+
+        return $this->fetch_results_boolean('/api/s/' . $this->site . '/cmd/productinfo', $payload);
+    }
+
+    /**
      * Upgrade a device to the latest firmware
      * ---------------------------------------
      * return true on success


### PR DESCRIPTION
I'm add possibility to check for controller and device firmwares updates. This information is cached by the controller.

Implement and test and the latest Unifi controller version _(6.0.28)_.