### PR TITLE
Receive $group_id in list_apgroups()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1083,7 +1083,7 @@ class Client
      *
      * @return array returns an array containing the current AP groups on success
      */
-    public function list_apgroups()
+    public function list_apgroups($group_id = null)
     {
         return $this->fetch_results('/v2/api/site/' . $this->site . '/apgroups/' . trim($group_id));
     }


### PR DESCRIPTION
function list_apgroups() is failing because a missing parameter $group_id