### PR TITLE
get_curl_resource() check for object instead of resource in PHP 8

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -3764,7 +3764,7 @@ class Client
     protected function get_curl_resource()
     {
         $ch = curl_init();
-        if (is_object($ch)) {
+        if (is_object($ch) || is_resource($ch)) {
             $curl_options = [
                 CURLOPT_SSL_VERIFYPEER => $this->curl_ssl_verify_peer,
                 CURLOPT_SSL_VERIFYHOST => $this->curl_ssl_verify_host,

--- a/src/Client.php
+++ b/src/Client.php
@@ -3764,7 +3764,7 @@ class Client
     protected function get_curl_resource()
     {
         $ch = curl_init();
-        if (is_resource($ch)) {
+        if (is_object($ch)) {
             $curl_options = [
                 CURLOPT_SSL_VERIFYPEER => $this->curl_ssl_verify_peer,
                 CURLOPT_SSL_VERIFYHOST => $this->curl_ssl_verify_host,


### PR DESCRIPTION
in PHP 8.0 curl_init() do not return a resource but a CurlHandle object
As a workaround, check for object instead of resource in get_curl_resource()