### PR TITLE
Basic class to control unifi LED lighting panels.

### DIFF
--- a/examples/led_panel_toggle.php
+++ b/examples/led_panel_toggle.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * PHP API usage example
+ *
+ * contributed by: Mike Siekkinen
+ * description:    example basic PHP script to turn on LED lighting panel group
+ */
+
+/**
+ * using the composer autoloader
+ */
+require_once 'vendor/autoload.php';
+
+/**
+ * include the config file (place your credentials etc. there if not already present)
+ * see the config.template.php file for an example
+ */
+require_once 'config.php';
+
+/**
+ * The LED panel group id assigned by controller you wish to control
+ */
+$led_panel_group_id = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+
+
+
+/**
+ * initialize the UniFi API connection class and log in to the controller and do our thing
+ */
+$unifi_connection = new UniFi_API\LEDClient($controlleruser, $controllerpassword, $controllerurl, $site_id, $controllerversion, false);
+$set_debug_mode   = $unifi_connection->set_debug(false);
+$loginresults     = $unifi_connection->login();
+$data = $unifi_connection->groupOn($led_panel_group_id);
+
+/**
+ * provide feedback in json format
+ */
+echo json_encode($data, JSON_PRETTY_PRINT);

--- a/src/Client.php
+++ b/src/Client.php
@@ -33,6 +33,7 @@ class Client
     protected $ssl_verify_host    = false;
     protected $is_loggedin        = false;
     protected $is_unifi_os        = false;
+    protected $unifi_os_endpoint   = '/proxy/network';
     protected $exec_retries       = 0;
     protected $cookies            = '';
     protected $headers            = [];
@@ -3802,7 +3803,7 @@ class Client
         $url = $this->baseurl . $path;
 
         if ($this->is_unifi_os) {
-            $url = $this->baseurl . '/proxy/network' . $path;
+            $url = $this->baseurl . $this->unifi_os_endpoint. $path;
         }
 
         $curl_options = [
@@ -3980,4 +3981,5 @@ class Client
 
         return false;
     }
+
 }

--- a/src/LEDClient.php
+++ b/src/LEDClient.php
@@ -1,0 +1,43 @@
+<?php
+namespace UniFi_API;
+
+class LEDClient extends Client {
+
+    protected $unifi_os_endpoint = '/proxy/led';
+
+    /**
+     * Set LED Panel group to specified value
+     *
+     * @param  string            $gid    group id to turn off
+     * @param  string            $value  0 = off; 1 = on
+     * @return bool|array                controller response
+     */
+    protected function groupSet($gid, $value){
+        $this->method = 'PUT';
+        $payload = [
+            'command'         => 'config-output',
+            'value' => "$value",
+        ];
+        return $this->fetch_results('/v2/groups/'.$gid, $payload);
+    }
+
+    /**
+     * Turn on LED Panel group specified
+     *
+     * @param  string            $gid    group id to turn off
+     * @return bool|array                controller response
+     */
+    function groupOn($gid){
+        return $this->groupSet($gid, "1");
+    }
+
+    /**
+     * Turn off LED Panel group specified
+     *
+     * @param  string            $gid    group id to turn off
+     * @return bool|array                controller response
+     */
+    function groupOff($gid){
+        return $this->groupSet($gid, "0");
+    }
+}


### PR DESCRIPTION
Coding structure was modeled off existing PR https://github.com/Art-of-WiFi/UniFi-API-client/pull/102/
that was adding a separate Protect Client.   Specifically adopting the Client::unifi_os_endpoint variable
for API path to LED controls.

Currently just an on and off method to start discussion on this set of changes

If this looks like a good direction and something you'd like to include I'm happy to fill out the LEDClient API further