### PR TITLE
Update list_clients to only trim and lowercase $client_mac if not null

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1039,7 +1039,10 @@ class Client
      */
     public function list_clients($client_mac = null)
     {
-        return $this->fetch_results('/api/s/' . $this->site . '/stat/sta/' . strtolower(trim($client_mac)));
+        if ($client_mac != null) {
+            $client_mac = strtolower(trim($client_mac));
+        }
+        return $this->fetch_results('/api/s/' . $this->site . '/stat/sta/' . $client_mac);
     }
 
     /**


### PR DESCRIPTION
In PHP8, I get this deprecation warning about using the `trim` function with a null input:
```
Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /.../art-of-wifi/unifi-api-client/src/Client.php on line 1042
```

Update the `list_clients` function to only trim and lowercase `client_mac` if it is not null.