### PR TITLE
Solve deprecated passing null to a string in PHP 8.1

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -2577,6 +2577,7 @@ class Client
      */
     public function list_wlanconf($wlan_id = null)
     {
+        if (is_null($wlan_id)) {$wlan_id = '';}
         return $this->fetch_results('/api/s/' . $this->site . '/rest/wlanconf/' . trim($wlan_id));
     }
 


### PR DESCRIPTION
Solve deprecated passing null to a string in list_wlanconf()
trim() function doesn't allow an input parameter not being a string.