### PR TITLE
Add `stat/device-basic` endpoint

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1398,6 +1398,16 @@ class Client
     }
 
     /**
+     * List of site devices with a basic subset of fields (e.g., mac, state, adopted, disabled, type, model, name)
+     *
+     * @return array|false an array containing known UniFi device objects), false upon error
+     */
+    public function list_devices_basic()
+    {
+        return $this->fetch_results('/api/s/' . $this->site . '/stat/device-basic');
+    }
+
+    /**
      * Fetch UniFi devices
      *
      * @param string $device_mac optional, the MAC address of a single UniFi device for which the call must be made


### PR DESCRIPTION
Adding missing (lightweight) endpoint for basic device information. Useful for filtering on `type` or other basic fields. Example output:

```json
{
    "meta": {
        "rc": "ok"
    },
    "data": [
        {
            "mac": "d0:21:f9:fa:5f:38",
            "state": 1,
            "adopted": true,
            "disabled": false,
            "type": "uap",
            "model": "U6M",
            "in_gateway_mode": false,
            "name": "AP Lab"
        },
        {
            "mac": "b4:fb:e4:d2:17:8c",
            "state": 2,
            "adopted": false,
            "disabled": false,
            "type": "usw",
            "model": "US8P60",
            "in_gateway_mode": false
        }
    ]
}
```