### PR TITLE
Add option to pass 2FA on login

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -119,7 +119,7 @@ class Client
      *
      * @return bool|int returns true upon success, false or HTTP status upon error
      */
-    public function login()
+    public function login($token_2fa = null)
     {
         /**
          * skip the login process if already logged in
@@ -155,12 +155,21 @@ class Client
             trigger_error('cURL error: ' . curl_error($ch));
         }
 
+        $fields = [
+            'username' => $this->user,
+            'password' => $this->password,
+        ];
+
+        if ($token_2fa !== null) {
+            $field['ubic_2fa_token'] = $token_2fa;
+        }
+        
         /**
          * prepare the actual login
          */
         $curl_options = [
             CURLOPT_POST       => true,
-            CURLOPT_POSTFIELDS => json_encode(['username' => $this->user, 'password' => $this->password]),
+            CURLOPT_POSTFIELDS => json_encode($fields),
             CURLOPT_HTTPHEADER => [
                 'content-type: application/json',
                 'Expect:',


### PR DESCRIPTION
**Issue:**

Some of the customers are trying to log in using accounts with 2FA, which just throws a generic login error.

**Solution:**

Pass the token as an argument at the time of the login.

**Note:**

- This change needs to be better tested. I've created this PR just to see if it is something that you would consider merging into the package.

- This is the simplest solution to this problem. Maybe we can do a different approach, such as setting the 2FA token as a property in the class, and then chain a set on it.

- I've seen that the API returns different errors on the login (for instance, for the issue described above it returns the `message api.err.Ubic2faTokenRequired` to do a better DX, we could throw different errors for different messages.