### PR TITLE
Add methods to get/create/delete device tag and set tagged devices

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1369,6 +1369,59 @@ class Client
     }
 
     /**
+     * Create (device) tag (using REST)
+     *
+     * NOTES: this endpoint was introduced with controller versions 5.5.X
+     *
+     * @param string $name required, the tag name to add
+     * @param array $devices_macs optional, array of the MAC addresses of one or multiple devices to tag with the new tag
+     *
+     * @return bool return true on success
+     */
+    public function create_tag($name, array $devices_macs = null)
+    {
+        $payload = ['name' => $name];
+        if ($devices_macs) $payload['member_table'] = $devices_macs;
+
+        return $this->fetch_results_boolean('/api/s/' . $this->site . '/rest/tag', $payload);
+    }
+
+    /**
+     * Set tagged devices (using REST)
+     *
+     * NOTES: this endpoint was introduced with controller versions 5.5.X
+     *
+     * @param array $devices_macs required, array of the MAC addresses of one or multiple devices to tag
+     * @param string $tag_id required, the _id value of the tag to set
+     *
+     * @return bool return true on success
+     */
+    public function set_tagged_devices(array $devices_macs, $tag_id)
+    {
+        $this->request_type = 'PUT';
+
+        $payload = ['member_table' => $devices_macs];
+
+        return $this->fetch_results_boolean('/api/s/' . $this->site . '/rest/tag/' . $tag_id, $payload);
+    }
+
+    /**
+     * Delete (device) tag (using REST)
+     *
+     * NOTES: this endpoint was introduced with controller versions 5.5.X
+     *
+     * @param string $tag_id required, the _id value of the tag to set
+     *
+     * @return bool return true on success
+     */
+    public function delete_tag($tag_id)
+    {
+        $this->request_type = 'DELETE';
+
+        return $this->fetch_results_boolean('/api/s/' . $this->site . '/rest/tag/' . $tag_id);
+    }
+
+    /**
      * Fetch rogue/neighboring access points
      *
      * @param int $within optional, hours to go back to list discovered "rogue" access points (default = 24 hours)

--- a/src/Client.php
+++ b/src/Client.php
@@ -1464,7 +1464,7 @@ class Client
      */
     public function set_tagged_devices(array $devices_macs, $tag_id)
     {
-        $this->request_type = 'PUT';
+        $this->curl_method = 'PUT';
 
         $payload = ['member_table' => $devices_macs];
 
@@ -1482,7 +1482,7 @@ class Client
      */
     public function delete_tag($tag_id)
     {
-        $this->request_type = 'DELETE';
+        $this->curl_method = 'DELETE';
 
         return $this->fetch_results_boolean('/api/s/' . $this->site . '/rest/tag/' . $tag_id);
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -1435,6 +1435,21 @@ class Client
     }
 
     /**
+     * Get (device) tag (using REST)
+     *
+     * NOTES: this endpoint was introduced with controller versions 5.5.X
+     *
+     * @param string $tag_id required, _id value of the tag to retreive
+     * @return array containing matching tag objects
+     */
+    public function get_tag($tag_id)
+    {
+        $this->curl_method = 'GET';
+
+        return $this->fetch_results('/api/s/' . $this->site . '/rest/tag/' . $tag_id);
+    }
+
+    /**
      * Create (device) tag (using REST)
      *
      * NOTES: this endpoint was introduced with controller versions 5.5.X

--- a/src/Client.php
+++ b/src/Client.php
@@ -2549,11 +2549,12 @@ class Client
 
     /**
      * Check controller update
-     * -----------------------
+     *
+     * NOTE:
+     * It's trigger an update of the controller cached known latest version.
+     *
      * @return array returns an array with a single object containing details of the current known latest controller version info
      *               on success, else returns false
-     *
-     * NOTE: It's trigger an update of the controller cached known latest version.
      */
     public function check_controller_update()
     {
@@ -2562,7 +2563,7 @@ class Client
 
     /**
      * Check firmware update
-     * ---------------------
+     *
      * @return bool returns true upon success
      */
     public function check_firmware_update()

--- a/src/Client.php
+++ b/src/Client.php
@@ -2550,7 +2550,8 @@ class Client
     /**
      * Check controller update
      * -----------------------
-     * returns current known latest controller version info
+     * @return array returns an array with a single object containing details of the current known latest controller version info
+     *               on success, else returns false
      *
      * NOTE: It's trigger an update of the controller cached known latest version.
      */
@@ -2562,7 +2563,7 @@ class Client
     /**
      * Check firmware update
      * ---------------------
-     * return true on success
+     * @return bool returns true upon success
      */
     public function check_firmware_update()
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -2548,6 +2548,30 @@ class Client
     }
 
     /**
+     * Check controller update
+     * -----------------------
+     * returns current known latest controller version info
+     *
+     * NOTE: It's trigger an update of the controller cached known latest version.
+     */
+    public function check_controller_update()
+    {
+        return $this->fetch_results('/api/s/' . $this->site . '/stat/fwupdate/latest-version');
+    }
+
+    /**
+     * Check firmware update
+     * ---------------------
+     * return true on success
+     */
+    public function check_firmware_update()
+    {
+        $payload = ['cmd' => 'check-firmware-update'];
+
+        return $this->fetch_results_boolean('/api/s/' . $this->site . '/cmd/productinfo', $payload);
+    }
+
+    /**
      * Upgrade a device to the latest firmware
      * ---------------------------------------
      * return true on success


### PR DESCRIPTION
Hello,

I already [made this PR](https://github.com/Art-of-WiFi/UniFi-API-client/pull/127) in past and it was accepted, but I can't find anymore the added methods. I propose it back with a fix of the method to set the HTTP request type and a new `get_tag()` method. Tested as functional on a 8.0.7-24256-1 Unifi controller.
