### PR TITLE
Add days parameter to generate_backup method

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1557,11 +1557,12 @@ class Client
      * Generate a backup
      *
      * @note this is an experimental function, please do not use unless you know exactly what you're doing
+     * @param int $days number of days for which the backup must be generated
      * @return array|bool URL from where the backup file can be downloaded once generated, false upon failure
      */
-    public function generate_backup()
+    public function generate_backup(int $days = -1)
     {
-        $payload = ['cmd' => 'backup'];
+        $payload = ['cmd' => 'backup', 'days' => $days];
 
         return $this->fetch_results('/api/s/' . $this->site . '/cmd/backup', $payload);
     }


### PR DESCRIPTION
Add a `days` parameter to the `generate_backup` method, similar to what the GUI supports.
![image](https://github.com/user-attachments/assets/b1cdf030-91a4-4db7-aa0c-efab1cd08e70)

Valid options in the GUI are: 0 (settings only), 7, 30, 60, 90, 180, 365, -1 (no limit).
The API seems to support any value.